### PR TITLE
optionally run build only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,28 @@ jobs:
     modify:
         name: Modifying source code
         runs-on: ubuntu-latest
+        outputs:
+            new_commits: ${{ steps.update.outputs.new_commits }}
         steps:
             - uses: actions/checkout@v2
               with:
                   submodules: true
             - name: Update submodule
               continue-on-error: true
+              id: update
               run: |
                   git submodule update --remote upstream
                   git config user.name "Sophie Keller"
                   git config user.email 90475612+skeller00@users.noreply.github.com
-                  git commit -am "Committing changes from upstream"
-                  git push
+                  if git commit -am "Committing changes from upstream"; then
+                    echo "new_commits=true" >> $GITHUB_OUTPUT
+                    git push
+                  else
+                    echo "There are no new commits, I'll go back to sleep :sleeping:" >> $GITHUB_STEP_SUMMARY
+                    echo "new_commits=false" >> $GITHUB_OUTPUT
+                  fi
             - name: Running modifications
+              if: steps.update.outputs.new_commits == 'true'
               run: |
                   sed -i \
                     -e "s/version=version/version=\"$(date +%Y.%m.%d)\"/g" upstream/setup.py \
@@ -33,6 +42,7 @@ jobs:
                     -e "s/Source=.*/Source=https:\/\/github.com\/keller00\/snowflake-connector-python-nightlies\//" \
                   upstream/setup.cfg
             - uses: actions/upload-artifact@v2
+              if: steps.update.outputs.new_commits == 'true'
               with:
                   name: modified_source
                   path: upstream
@@ -40,6 +50,7 @@ jobs:
         name: Build sdist
         runs-on: ubuntu-latest
         needs: modify
+        if: needs.modify.outputs.new_commits == 'true' && needs.modify.result == 'success'
         steps:
             - uses: actions/setup-python@v4
               with:
@@ -60,6 +71,7 @@ jobs:
         name: Build py${{ matrix.python }} ${{ matrix.os }}
         runs-on: ${{ matrix.os }}
         needs: modify
+        if: needs.modify.outputs.new_commits == 'true' && needs.modify.result == 'success'
         defaults:
             run:
                 shell: bash
@@ -95,6 +107,7 @@ jobs:
         name: Release built wheels
         runs-on: ubuntu-latest
         needs: [build-wheel, build-sdist]
+        if: needs.build-wheel.result == 'success' && needs.build-sdist.result == 'success'
         steps:
             - uses: actions/download-artifact@v3
               with:


### PR DESCRIPTION
If this PR is bug free then we should only release nightly builds if there are new commits in the official repo.
closes #2 